### PR TITLE
add network namespace support

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -51,21 +51,21 @@ func New(devices func() ([]*wgtypes.Device, error), peerNames map[string]string)
 		PeerReceiveBytes: prometheus.NewDesc(
 			"wireguard_peer_receive_bytes_total",
 			"Number of bytes received from a given peer.",
-			[]string{"public_key"},
+			[]string{"public_key", "device"},
 			nil,
 		),
 
 		PeerTransmitBytes: prometheus.NewDesc(
 			"wireguard_peer_transmit_bytes_total",
 			"Number of bytes transmitted to a given peer.",
-			[]string{"public_key"},
+			[]string{"public_key", "device"},
 			nil,
 		),
 
 		PeerLastHandshake: prometheus.NewDesc(
 			"wireguard_peer_last_handshake_seconds",
 			"UNIX timestamp for the last handshake with a given peer.",
-			[]string{"public_key"},
+			[]string{"public_key", "device"},
 			nil,
 		),
 
@@ -132,6 +132,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.CounterValue,
 				float64(p.ReceiveBytes),
 				pub,
+				d.Name,
 			)
 
 			ch <- prometheus.MustNewConstMetric(
@@ -139,6 +140,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.CounterValue,
 				float64(p.TransmitBytes),
 				pub,
+				d.Name,
 			)
 
 			ch <- prometheus.MustNewConstMetric(
@@ -146,6 +148,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				float64(p.LastHandshakeTime.Unix()),
 				pub,
+				d.Name,
 			)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/common v0.7.0 // indirect
 	github.com/prometheus/procfs v0.0.5 // indirect
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	golang.org/x/crypto v0.0.0-20191001170739-f9e2070545dc // indirect
 	golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24 // indirect
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20190925195211-ef61b881e46f

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
I have a use case where I want to scrape multiple network namespaces with wireguard interfaces in each one. I don't want to have to spin up an exporter per network namespace though.. so I figured it was much simpler to just allow the exporter to switch between the namespaces during collection.

Seems to work as is, but definitely open to comments and suggestions.