### PR TITLE
Fail startup if cannot list WireGuard devices

### DIFF
--- a/cmd/wireguard_exporter/main.go
+++ b/cmd/wireguard_exporter/main.go
@@ -50,6 +50,10 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle(*metricsPath, promhttp.Handler())
 
+	if _, err := client.Devices(); err != nil {
+		log.Fatalf("failed to retrieve wireguard devices: %v", err)
+	}
+
 	// Start listening for HTTP connections.
 	log.Printf("starting WireGuard exporter on %q", *metricsAddr)
 	if err := http.ListenAndServe(*metricsAddr, mux); err != nil {


### PR DESCRIPTION
If user does not have permission to read wireguard status,
the exporter should fail instead of silently returning no
results.

List the device names on start to make it easier to understand
why no results are returned.